### PR TITLE
Ensure that templates are installed.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(name='plotlyhtmlexporter',
                         'nbformat>=4.2'
                         'traitlets',
                         ],
+      include_package_data=True,
       zip_safe=False,
       entry_points={
           'nbconvert.exporters': [


### PR DESCRIPTION
`setup.py` call was missing the necessary flag for the data in `manifest.in` to
be picked up at install time.

Cf: http://python-packaging.readthedocs.io/en/latest/non-code-files.html

BTW, the best way to catch these issues is to run the test suite on Travis, so that there's an automatic check on a regular install. I imagine everything was working for the devs, who typically (I do the same) run from a local dev-mode install for efficiency.  Otherwise things like this happen pretty easily, I know I've fallen often in the same trap.